### PR TITLE
Added new html/css roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sass-cache

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -6,6 +6,9 @@ $text-color: #666;
 $text-dark: #383838;
 $verge-blue: #08b4e0;
 
+$bg-dark: #383838;
+$bg-dark2: #454545;
+
 h1 {
   font-size: 38px;
   font-weight: 600;
@@ -74,7 +77,7 @@ ul {
 }
 
 .bg-dark {
-  background: #383838;
+  background: $bg-dark;
 
   h1 {
     color: #fff;
@@ -125,7 +128,7 @@ ul {
     &:hover {
       svg #verge {
         path {
-          fill: #383838;
+          fill: $text-dark;
         }
       }
     }
@@ -171,7 +174,7 @@ a {
     margin-left: 1em;
 
     a {
-      color: #383838;
+      color: $text-dark;
     }
   }
 }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -185,6 +185,7 @@ a {
 }
 
 @import
+  "roadmap",
   "normalize",
   "skeleton"
 ;

--- a/_sass/roadmap.scss
+++ b/_sass/roadmap.scss
@@ -1,0 +1,179 @@
+/* -------------------------------- 
+
+Roadmap
+
+-------------------------------- */
+
+.cd-container {
+  width: 100%;
+  margin: 0 auto;
+  background: $bg-dark;
+  padding: 0 10%;
+  border-radius: 2px;
+}
+
+.cd-container::after {
+  content: '';
+  display: table;
+  clear: both;
+}
+
+#cd-timeline {
+  position: relative;
+  padding: 2em 0;
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+#cd-timeline::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 25px;
+  height: 100%;
+  width: 4px;
+  background: $verge-blue;
+}
+
+.cd-timeline-block {
+  position: relative;
+  margin: 2em 0;
+}
+
+.cd-timeline-block:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.cd-timeline-block:first-child {
+  margin-top: 0;
+}
+
+.cd-timeline-block:last-child {
+  margin-bottom: 0;
+}
+
+.cd-timeline-img {
+  position: absolute;
+  top: 35%;
+  left: 12px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: #317b96;
+  box-shadow: 0 0 0 4px $verge-blue, inset 0 2px 0 rgba(0, 0, 0, 0.08), 0 3px 0 4px rgba(0, 0, 0, 0.05);
+}
+
+.cd-timeline-img.completed {
+  background: #08b4e0;
+}
+
+.cd-timeline-content {
+  position: relative;
+  margin-left: 60px;
+  margin-right: 30px;
+  background: $bg-dark2;
+  border-radius: 2px;
+  padding: 1em;
+
+  .timeline-content-info {
+    background: $bg-dark;
+    padding: 5px 10px;
+    color: rgba(255,255,255,0.7);
+    font-size: 12px;
+    box-shadow:  inset 0 2px 0 rgba(0, 0, 0, 0.08);
+    border-radius: 2px;
+
+    i {
+      margin-right: 5px;
+    }
+
+    .timeline-content-info-title, .timeline-content-info-date {  
+      width: calc(50% - 2px);
+      display: inline-block;
+    }
+
+    @media (max-width: 500px) {
+      .timeline-content-info-title, .timeline-content-info-date {  
+        display: block;
+        width:100%;
+      } 
+    }
+  }
+
+  .content-skills {
+    font-size: 12px;
+    padding:0;
+    margin-bottom: 0;
+    display:flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    
+    li {
+      background: #40484D;
+      border-radius: 2px;
+      display: inline-block;
+      padding: 2px 10px;
+      color: rgba(255,255,255,0.7);
+      margin: 3px 2px;
+      text-align: center;
+      flex-grow: 1;
+    }
+  }
+}
+
+.cd-timeline-content:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.cd-timeline-content h2 {
+  color: rgba(255,255,255,.9);
+  margin-top:0;
+  margin-bottom: 5px;
+}
+
+.cd-timeline-content p, .cd-timeline-content .cd-date {
+  color: rgba(255,255,255,.7);
+  font-size: 13px;
+  font-size: 0.8125rem;
+}
+
+.cd-timeline-content .cd-date {
+  display: inline-block;
+}
+
+.cd-timeline-content p {
+  margin: 1em 0;
+  line-height: 1.6;
+}
+
+.cd-timeline-content::before {
+  content: '';
+  position: absolute;
+  top: 40%;
+  right: 100%;
+  height: 0;
+  width: 0;
+  border: 10px solid transparent;
+  border-right: 10px solid $bg-dark2;
+}
+
+@media only screen and (min-width: 768px) {
+  .cd-timeline-content h2 {
+    font-size: 20px;
+    font-size: 1.25rem;
+  }
+
+  .cd-timeline-content p {
+    font-size: 16px;
+    font-size: 1rem;
+  }
+
+  .cd-timeline-content .cd-read-more, .cd-timeline-content .cd-date {
+    font-size: 14px;
+    font-size: 0.875rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -109,14 +109,109 @@ layout: home
     </div>
   </div>
 </div>
-<div class="section bg-blue">
+<div class="section">
   <div class="row">
     <div class="twelve columns">
-      <div class="card" id="roadmap">
+      <div id="roadmap">
         <h1>Road Map</h1>
-        <ul>
-    	<img src="./images/roadmap.png">
-        </ul>
+        <section id="cd-timeline" class="cd-container">
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img completed cd-picture"></div>
+            <div class="cd-timeline-content">
+              <h2>"Black" Paper</h2>
+              <span class="cd-date">June 4, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img completed cd-movie"></div>
+            <div class="cd-timeline-content">
+              <h2>Electrum i2p Server/Client</h2>
+              <span class="cd-date">June 4, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img completed cd-picture"></div>
+            <div class="cd-timeline-content">
+              <h2>Electrum TOR Server/Client</h2>
+              <span class="cd-date">June 5, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img completed cd-movie"></div>
+            <div class="cd-timeline-content">
+              <h2>Electrum Binaries</h2>
+              <span class="cd-date">June 7, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-picture"></div>
+            <div class="cd-timeline-content">
+              <h2>Crypto Services Marketing Campaign</h2>
+              <p>
+                Started 1 year ad campaign with Coinomi
+              </p>
+              <span class="cd-date">June 7, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-movie"></div>
+            <div class="cd-timeline-content">
+              <h2>Redesign Verge Website</h2>
+              <span class="cd-date">June 12, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-picture"></div>
+            <div class="cd-timeline-content">
+              <h2>Expand Verge Radio</h2>
+              <p>
+                Transform into "RadioCrypto" and include in core wallets
+              </p>
+              <span class="cd-date">June 26, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-movie"></div>
+            <div class="cd-timeline-content">
+              <h2>i2P/TOR Android Wallets</h2>
+              <span class="cd-date">July, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-picture"></div>
+            <div class="cd-timeline-content">
+              <h2>New Core Wallet Release</h2>
+              <p>
+                Add new features including coin control, RingCT, update libraries (openssl, boost, etc)
+              </p>
+              <span class="cd-date">July, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-movie"></div>
+            <div class="cd-timeline-content">
+              <h2>RSK smart contracts</h2>
+              <p>
+                They are in testnet now
+              </p>
+              <span class="cd-date">July, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-picture"></div>
+            <div class="cd-timeline-content">
+              <h2>Wallet UI overhaul</h2>
+              <span class="cd-date">July, 2017</span>
+            </div>
+          </div>
+          <div class="cd-timeline-block">
+            <div class="cd-timeline-img cd-movie"></div>
+            <div class="cd-timeline-content">
+              <h2>Merchandise Online Store</h2>
+              <span class="cd-date">July, 2017</span>
+            </div>
+          </div>
+        </section>
       </div>
     </div>
   </div>


### PR DESCRIPTION
@vergecurrency @CryptoRekt 

This PR does the following:

- Updates the Verge homepage roadmap to an HTML/CSS version

**Benefits:**
  - Adding/removing items will be easier, since you will not need to update an image (just add/remove html)
 - Page load time will decrease because you will not need to load a large image

![verge_roadmap](https://user-images.githubusercontent.com/595663/27175514-427a8a28-5174-11e7-98e8-9fc0e870dd27.gif)

**Screen shots**

_Desktop_
![screen shot 2017-06-15 at 2 42 34 am](https://user-images.githubusercontent.com/595663/27175664-bc44da3e-5174-11e7-8d7b-847898f78465.png)

_Mobile Web_
![screen shot 2017-06-15 at 2 43 12 am](https://user-images.githubusercontent.com/595663/27175675-c2876682-5174-11e7-9aaf-23208b042c02.png)

