### PR TITLE
Added Twitter Timeline to the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@ layout: home
             </div>
           </div>
           <div class="cd-timeline-block">
-            <div class="cd-timeline-img cd-picture"></div>
+            <div class="cd-timeline-img completed cd-picture"></div>
             <div class="cd-timeline-content">
               <h2>Crypto Services Marketing Campaign</h2>
               <p>
@@ -157,7 +157,7 @@ layout: home
             </div>
           </div>
           <div class="cd-timeline-block">
-            <div class="cd-timeline-img cd-movie"></div>
+            <div class="cd-timeline-img completed cd-movie"></div>
             <div class="cd-timeline-content">
               <h2>Redesign Verge Website</h2>
               <span class="cd-date"><font color="red">RELEASED</font> June 12, 2017</span>
@@ -177,7 +177,7 @@ layout: home
             <div class="cd-timeline-img cd-movie"></div>
             <div class="cd-timeline-content">
               <h2>i2P/TOR Android Wallets</h2>
-		    <p>
+		          <p>
                 Android Wallet for Anon transactions ONLY! (near completion)
               </p>
               <span class="cd-date">July, 2017</span>
@@ -227,7 +227,7 @@ layout: home
 </div>
 <div class="section end-section bg-dark">
   <div class="row">
-    <div class="twelve columns" id="community">
+    <div class="six columns" id="community">
       <h1>Community</h1>
       <ul>
         <li><a href="https://verge.typeform.com/to/RxDLtL" target="_blank">Slack</a></li>
@@ -239,9 +239,18 @@ layout: home
         <li><a href="http://steamcommunity.com/groups/vergecurrency" target="_blank">Steam</a></li>
         <li><a href="https://t.me/VERGExvg" target="_blank">Telegram</a></li>
         <li><a href="http://vergecurrency.com/radio/" target="_blank">Verge Radio</a></li>
-	<li><a href="https://discord.gg/ehjyKQv" target="_blank">Verge Discord </a></li>
+	      <li><a href="https://discord.gg/ehjyKQv" target="_blank">Verge Discord </a></li>
       </ul>
+    </div>
+    <div class="six columns" id="twitter-timeline">
+      <h1>Tweets</h1>
+        <a href="https://twitter.com/vergecurrency" data-chrome="noheader nofooter transparent noborders" data-theme="dark" data-link-color="#08b4e0" height="450px" class="twitter-timeline">
+          Tweets by @vergecurrency
+        </a>
     </div>
   </div>
   <div class="footer">&copy; 2017 Verge</div>
 </div>
+<script>
+!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
+</script>


### PR DESCRIPTION
@vergecurrency @CryptoRekt 

This PR does the following:

- Updates the Verge footer to include the [vergecurrency](https://twitter.com/vergecurrency) twitter stream

_Desktop_
![screen shot 2017-06-15 at 9 36 15 pm](https://user-images.githubusercontent.com/595663/27212305-ec86d202-5213-11e7-9be4-8ef7e59f6176.png)

_Mobile Web_
![screen shot 2017-06-15 at 9 43 32 pm](https://user-images.githubusercontent.com/595663/27212307-f1d3b248-5213-11e7-8209-a4e870abbf17.png)