### PR TITLE
Add Wallet Tabs

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -7,10 +7,12 @@ body {
   box-sizing: border-box;
 }
 
-$text-color: #666;
+$text-color: #666666;
 $text-dark: #383838;
 $verge-blue: #08b4e0;
+$light-gray: #DDDDDD;
 
+$bg-gray: #EEEEEE;
 $bg-dark: #383838;
 $bg-dark2: #454545;
 
@@ -86,7 +88,7 @@ ul {
 }
 
 .bg-gray {
-  background: #eee;
+  background: $bg-gray;
 }
 
 .bg-dark {
@@ -213,6 +215,7 @@ a.button {
   "bootstrap-grid",
   "normalize",
   "skeleton",
+  "wallet-tabs",
   "wallet-download-buttons",
   "roadmap",
   "cloud-animation"

--- a/_sass/wallet-tabs.scss
+++ b/_sass/wallet-tabs.scss
@@ -1,0 +1,37 @@
+.tab-content {
+  display: none;
+  padding: 20px 0 0;
+  border-top: 1px solid $light-gray;
+}
+
+input[type="radio"].tab-radio {
+  display: none;
+}
+
+.tab-label {
+  display: inline-block;
+  margin: 0 0 -1px;
+  padding: 15px 25px;
+  font-weight: 600;
+  text-align: center;
+  color: #bbb;
+  border: 1px solid transparent;
+}
+
+.tab-label:hover {
+  color: #888;
+  cursor: pointer;
+}
+
+.tab-radio:checked + label {
+  color: #555;
+  border: 1px solid $light-gray;
+  border-top: 2px solid $verge-blue;
+  border-bottom: 1px solid white;
+}
+
+#desktop-tab:checked ~ #desktop-content,
+#mobile-tab:checked ~ #mobile-content,
+#other-tab:checked ~ #other-content, {
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@ layout: home
     <ul class="nav">
       <li><a href="#about">About</a></li>
       <li><a href="#exchanges">Get Verge</a></li>
-      <li><a href="#roadmap">Road Map</a></li>
       <li><a href="#wallets">Wallets</a></li>
+      <li><a href="#roadmap">Road Map</a></li>
       <li><a href="#community">Community</a></li>
     </ul>
   </header>
@@ -294,6 +294,233 @@ layout: home
     </div>
   </div>
 </section>
+<section class="section col-sm-12" id="wallets">
+  <div class="row">
+    <div class="twelve columns">
+      <h1>Wallets</h1>
+      <div class="tabs">
+        <input id="desktop-tab" type="radio" name="tabs" class="tab-radio" checked>
+        <label for="desktop-tab" class="tab-label">Desktop</label>
+          
+        <input id="mobile-tab" type="radio" name="tabs" class="tab-radio">
+        <label for="mobile-tab" class="tab-label">Mobile</label>
+          
+        <input id="other-tab" type="radio" name="tabs" class="tab-radio">
+        <label for="other-tab" class="tab-label">Other</label>
+          
+        <section id="desktop-content" class="tab-content">
+          <ul class="footer-wallet-download-buttons-list twelve columns">
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/VERGE-Windows.zip" class="button wallet-download-button windows-download-button">
+                <i class="fa fa-windows wallet-download-button-icon" aria-hidden="true"></i>
+                <span class="wallet-download-button-download-text">
+                  Download
+                </span>
+                <span class="wallet-download-button-description-text">Verge Windows Wallet</span>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/verge-qt-osx.dmg" class="button wallet-download-button macos-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fa-apple wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Mac OSX Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/arch_2.1.0.tar" class="button wallet-download-button arch-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fl-archlinux wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge ArchLinux Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/centos7_2.1.0.tar" class="button wallet-download-button centos-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fl-centos wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge CentOS Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/debian8_v2.1.0.tar" class="button wallet-download-button debian-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fl-debian wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Debian Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/fedora23_2.1.0.tar" class="button wallet-download-button fedora-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fl-fedora wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Fedora Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/electrum-xvg" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fa-linux wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Linux Electrum Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/electrum-xvg/releases/download/2.2.0.1/electrum-xvg.zip" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fa-windows wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Windows Electrum Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/electrum-xvg-tor" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa wallet-download-button-icon" aria-hidden="true">
+                  <svg width="22" height="22" fill="white" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+                   <g transform="translate(-58.12 -303.3)">
+                    <path d="m77.15 303.3c-1.608 1.868-0.09027 2.972-0.9891 4.84 1.514-2.129 5.034-2.862 7.328-3.643-3.051 2.72-5.457 6.326-8.489 9.009l-1.975-0.8374c-0.4647-4.514-1.736-4.705 4.125-9.369z" fill-rule="evenodd"/>
+                    <path d="m74.04 313.1 2.932 0.9454c-0.615 2.034 0.3559 2.791 0.9472 3.123 1.324 0.7332 2.602 1.49 3.619 2.412 1.916 1.75 3.004 4.21 3.004 6.812 0 2.578-1.183 5.061-3.169 6.717-1.868 1.561-4.446 2.223-6.953 2.223-1.561 0-2.956-0.0708-4.47-0.5677-3.453-1.159-6.031-4.115-6.244-7.663-0.1893-2.767 0.4257-4.872 2.578-7.072 1.111-1.159 2.563-2.749 4.1-3.813 0.757-0.5204 1.119-1.191-0.4183-3.958l1.28-1.076 2.795 1.918-2.352-0.3007c0.1656 0.2366 1.189 0.7706 1.284 1.078 0.2128 0.8751-0.1911 1.771-0.3804 2.149-0.9696 1.75-1.86 2.275-3.066 3.268-2.129 1.75-4.27 2.836-4.01 7.637 0.1183 2.365 1.433 5.295 4.2 6.643 1.561 0.757 2.859 1.189 4.68 1.284 1.632 0.071 4.754-0.8988 6.457-2.318 1.821-1.514 2.838-3.808 2.838-6.149 0-2.365-0.9461-4.612-2.72-6.197-1.017-0.9223-2.696-2.034-3.737-2.625-1.041-0.5912-2.782-2.06-2.356-3.645z"/>
+                    <path d="m73.41 316.6c-0.186 1.088-0.4177 3.117-0.8909 3.917-0.3293 0.5488-0.4126 0.8101-0.7846 1.094-1.09 1.535-1.45 1.761-2.132 4.552-0.1447 0.5914-0.3832 1.516-0.2591 2.107 0.372 1.703 0.6612 2.874 1.316 4.103 0 0 0.1271 0.1217 0.1271 0.169 0.6821 0.9225 0.6264 1.05 2.665 2.246l-0.06204 0.3313c-1.55-0.4729-2.604-0.9591-3.41-2.024 0-0.0236-0.1513-0.1558-0.1513-0.1558-0.868-1.135-1.753-2.788-2.021-4.546-0.1447-0.7097-0.0769-1.341 0.08833-2.075 0.7026-2.885 1.415-4.093 2.744-5.543 0.3514-0.2601 0.6704-0.6741 1.001-1.092 0.4859-0.6764 1.462-2.841 1.814-4.189z"/>
+                    <path d="m74.09 318.6c0.0237 1.04 0.0078 3.036 0.3389 3.796 0.0945 0.2599 0.3274 1.414 0.9422 2.794 0.4258 0.96 0.5418 1.933 0.6128 2.193 0.2838 1.14-0.4002 3.086-0.8734 4.906-0.2364 0.98-0.6051 1.773-1.371 2.412l0.2796 0.3593c0.5204-0.02 1.954-1.096 2.403-2.416 0.757-2.24 1.328-3.317 0.9729-5.797-0.0473-0.2402-0.2094-1.134-0.6588-2.014-0.6622-1.34-1.474-2.614-1.592-2.874-0.213-0.4198-1.007-2.119-1.054-3.359z"/>
+                    <path d="m74.88 313.9 0.9727 0.4962c-0.09145 0.6403 0.04572 2.059 0.686 2.424 2.836 1.761 5.512 3.683 6.565 5.604 3.751 6.771-2.63 13.04-8.143 12.44 2.996-2.219 4.428-6.583 3.307-11.55-0.4574-1.944-1.729-3.893-2.987-5.883-0.545-0.9768-0.3547-2.188-0.4006-3.538z" fill-rule="evenodd"/>
+                    <rect x="73.07" y="312.8" width="1" height="22"/>
+                   </g>
+                  </svg>
+                </i>
+                <div class="wallet-download-button-description-text">Verge TOR Linux Electrum Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/electrum-xvg-tor/releases/download/2.2.0.1/electrum-xvg-tor-win64.zip" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa wallet-download-button-icon" aria-hidden="true">
+                  <svg width="22" height="22" fill="white" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+                   <g transform="translate(-58.12 -303.3)">
+                    <path d="m77.15 303.3c-1.608 1.868-0.09027 2.972-0.9891 4.84 1.514-2.129 5.034-2.862 7.328-3.643-3.051 2.72-5.457 6.326-8.489 9.009l-1.975-0.8374c-0.4647-4.514-1.736-4.705 4.125-9.369z" fill-rule="evenodd"/>
+                    <path d="m74.04 313.1 2.932 0.9454c-0.615 2.034 0.3559 2.791 0.9472 3.123 1.324 0.7332 2.602 1.49 3.619 2.412 1.916 1.75 3.004 4.21 3.004 6.812 0 2.578-1.183 5.061-3.169 6.717-1.868 1.561-4.446 2.223-6.953 2.223-1.561 0-2.956-0.0708-4.47-0.5677-3.453-1.159-6.031-4.115-6.244-7.663-0.1893-2.767 0.4257-4.872 2.578-7.072 1.111-1.159 2.563-2.749 4.1-3.813 0.757-0.5204 1.119-1.191-0.4183-3.958l1.28-1.076 2.795 1.918-2.352-0.3007c0.1656 0.2366 1.189 0.7706 1.284 1.078 0.2128 0.8751-0.1911 1.771-0.3804 2.149-0.9696 1.75-1.86 2.275-3.066 3.268-2.129 1.75-4.27 2.836-4.01 7.637 0.1183 2.365 1.433 5.295 4.2 6.643 1.561 0.757 2.859 1.189 4.68 1.284 1.632 0.071 4.754-0.8988 6.457-2.318 1.821-1.514 2.838-3.808 2.838-6.149 0-2.365-0.9461-4.612-2.72-6.197-1.017-0.9223-2.696-2.034-3.737-2.625-1.041-0.5912-2.782-2.06-2.356-3.645z"/>
+                    <path d="m73.41 316.6c-0.186 1.088-0.4177 3.117-0.8909 3.917-0.3293 0.5488-0.4126 0.8101-0.7846 1.094-1.09 1.535-1.45 1.761-2.132 4.552-0.1447 0.5914-0.3832 1.516-0.2591 2.107 0.372 1.703 0.6612 2.874 1.316 4.103 0 0 0.1271 0.1217 0.1271 0.169 0.6821 0.9225 0.6264 1.05 2.665 2.246l-0.06204 0.3313c-1.55-0.4729-2.604-0.9591-3.41-2.024 0-0.0236-0.1513-0.1558-0.1513-0.1558-0.868-1.135-1.753-2.788-2.021-4.546-0.1447-0.7097-0.0769-1.341 0.08833-2.075 0.7026-2.885 1.415-4.093 2.744-5.543 0.3514-0.2601 0.6704-0.6741 1.001-1.092 0.4859-0.6764 1.462-2.841 1.814-4.189z"/>
+                    <path d="m74.09 318.6c0.0237 1.04 0.0078 3.036 0.3389 3.796 0.0945 0.2599 0.3274 1.414 0.9422 2.794 0.4258 0.96 0.5418 1.933 0.6128 2.193 0.2838 1.14-0.4002 3.086-0.8734 4.906-0.2364 0.98-0.6051 1.773-1.371 2.412l0.2796 0.3593c0.5204-0.02 1.954-1.096 2.403-2.416 0.757-2.24 1.328-3.317 0.9729-5.797-0.0473-0.2402-0.2094-1.134-0.6588-2.014-0.6622-1.34-1.474-2.614-1.592-2.874-0.213-0.4198-1.007-2.119-1.054-3.359z"/>
+                    <path d="m74.88 313.9 0.9727 0.4962c-0.09145 0.6403 0.04572 2.059 0.686 2.424 2.836 1.761 5.512 3.683 6.565 5.604 3.751 6.771-2.63 13.04-8.143 12.44 2.996-2.219 4.428-6.583 3.307-11.55-0.4574-1.944-1.729-3.893-2.987-5.883-0.545-0.9768-0.3547-2.188-0.4006-3.538z" fill-rule="evenodd"/>
+                    <rect x="73.07" y="312.8" width="1" height="22"/>
+                   </g>
+                  </svg>
+                </i>
+                <div class="wallet-download-button-description-text">Verge TOR Windows Electrum Wallet</div>
+              </a>
+            </li>
+          </ul>
+        </section>
+        <section id="mobile-content" class="tab-content">
+          <ul class="footer-wallet-download-buttons-list twelve columns">
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/verge-android.apk" class="button wallet-download-button android-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fa-android wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Android Wallet</div>
+              </a>
+            </li>
+          </ul>
+        </section>
+        <section id="other-content" class="tab-content">
+          <ul class="footer-wallet-download-buttons-list twelve columns">
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="http://verge-wallet.xyz" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  View
+                </div>
+                <i class="fa fa-chrome wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Web Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/raspi/" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fl-raspberry-pi wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Raspberry Pi Source Code</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="http://vcmlfg3fgsmy2teu.onion" target="_blank" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa wallet-download-button-icon" aria-hidden="true">
+                  <svg width="22" height="22" fill="white" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+                   <g transform="translate(-58.12 -303.3)">
+                    <path d="m77.15 303.3c-1.608 1.868-0.09027 2.972-0.9891 4.84 1.514-2.129 5.034-2.862 7.328-3.643-3.051 2.72-5.457 6.326-8.489 9.009l-1.975-0.8374c-0.4647-4.514-1.736-4.705 4.125-9.369z" fill-rule="evenodd"/>
+                    <path d="m74.04 313.1 2.932 0.9454c-0.615 2.034 0.3559 2.791 0.9472 3.123 1.324 0.7332 2.602 1.49 3.619 2.412 1.916 1.75 3.004 4.21 3.004 6.812 0 2.578-1.183 5.061-3.169 6.717-1.868 1.561-4.446 2.223-6.953 2.223-1.561 0-2.956-0.0708-4.47-0.5677-3.453-1.159-6.031-4.115-6.244-7.663-0.1893-2.767 0.4257-4.872 2.578-7.072 1.111-1.159 2.563-2.749 4.1-3.813 0.757-0.5204 1.119-1.191-0.4183-3.958l1.28-1.076 2.795 1.918-2.352-0.3007c0.1656 0.2366 1.189 0.7706 1.284 1.078 0.2128 0.8751-0.1911 1.771-0.3804 2.149-0.9696 1.75-1.86 2.275-3.066 3.268-2.129 1.75-4.27 2.836-4.01 7.637 0.1183 2.365 1.433 5.295 4.2 6.643 1.561 0.757 2.859 1.189 4.68 1.284 1.632 0.071 4.754-0.8988 6.457-2.318 1.821-1.514 2.838-3.808 2.838-6.149 0-2.365-0.9461-4.612-2.72-6.197-1.017-0.9223-2.696-2.034-3.737-2.625-1.041-0.5912-2.782-2.06-2.356-3.645z"/>
+                    <path d="m73.41 316.6c-0.186 1.088-0.4177 3.117-0.8909 3.917-0.3293 0.5488-0.4126 0.8101-0.7846 1.094-1.09 1.535-1.45 1.761-2.132 4.552-0.1447 0.5914-0.3832 1.516-0.2591 2.107 0.372 1.703 0.6612 2.874 1.316 4.103 0 0 0.1271 0.1217 0.1271 0.169 0.6821 0.9225 0.6264 1.05 2.665 2.246l-0.06204 0.3313c-1.55-0.4729-2.604-0.9591-3.41-2.024 0-0.0236-0.1513-0.1558-0.1513-0.1558-0.868-1.135-1.753-2.788-2.021-4.546-0.1447-0.7097-0.0769-1.341 0.08833-2.075 0.7026-2.885 1.415-4.093 2.744-5.543 0.3514-0.2601 0.6704-0.6741 1.001-1.092 0.4859-0.6764 1.462-2.841 1.814-4.189z"/>
+                    <path d="m74.09 318.6c0.0237 1.04 0.0078 3.036 0.3389 3.796 0.0945 0.2599 0.3274 1.414 0.9422 2.794 0.4258 0.96 0.5418 1.933 0.6128 2.193 0.2838 1.14-0.4002 3.086-0.8734 4.906-0.2364 0.98-0.6051 1.773-1.371 2.412l0.2796 0.3593c0.5204-0.02 1.954-1.096 2.403-2.416 0.757-2.24 1.328-3.317 0.9729-5.797-0.0473-0.2402-0.2094-1.134-0.6588-2.014-0.6622-1.34-1.474-2.614-1.592-2.874-0.213-0.4198-1.007-2.119-1.054-3.359z"/>
+                    <path d="m74.88 313.9 0.9727 0.4962c-0.09145 0.6403 0.04572 2.059 0.686 2.424 2.836 1.761 5.512 3.683 6.565 5.604 3.751 6.771-2.63 13.04-8.143 12.44 2.996-2.219 4.428-6.583 3.307-11.55-0.4574-1.944-1.729-3.893-2.987-5.883-0.545-0.9768-0.3547-2.188-0.4006-3.538z" fill-rule="evenodd"/>
+                    <rect x="73.07" y="312.8" width="1" height="22" />
+                   </g>
+                  </svg>
+                </i>
+                <div class="wallet-download-button-description-text">Verge TOR Web Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="http://vhne4ia27avp7gtyltlj3fumq6ps343vap3gy3zqs7gj4yp2mbdq.b32.i2p/" target="_blank" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa wallet-download-button-icon" aria-hidden="true">
+                i2P
+                </i>
+                <div class="wallet-download-button-description-text">Verge i2P Web Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="http://vergecurrency.com/paper-wallet/index.html" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fa-newspaper-o wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Paper Wallet</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://github.com/vergecurrency/Docker-Verge-Daemon/" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fl-docker wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Verge Daemon Docker Image</div>
+              </a>
+            </li>
+            <li class="col-xs-12 col-sm-6 col-md-4">
+              <a href="https://play.google.com/store/apps/details?id=com.coinomi.wallet" class="button wallet-download-button">
+                <div class="wallet-download-button-download-text">
+                  Download
+                </div>
+                <i class="fa fa-android wallet-download-button-icon" aria-hidden="true"></i>
+                <div class="wallet-download-button-description-text">Coinomi Multi Currency Android Wallet</div>
+              </a>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  </div>
+</section>
 <section class="section col-sm-12" id="roadmap">
   <div class="row">
     <div class="twelve columns">
@@ -431,212 +658,6 @@ layout: home
           </div>
         </section>
       </div>
-    </div>
-  </div>
-</section>
-<section class="section col-sm-12 bg-gray" id="wallets">
-  <div class="row">
-    <div class="twelve columns">
-      <h1>Wallets</h1>
-        <ul class="footer-wallet-download-buttons-list twelve columns">
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/VERGE-Windows.zip" class="button wallet-download-button windows-download-button">
-              <i class="fa fa-windows wallet-download-button-icon" aria-hidden="true"></i>
-              <span class="wallet-download-button-download-text">
-                Download
-              </span>
-              <span class="wallet-download-button-description-text">Verge Windows Wallet</span>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/verge-qt-osx.dmg" class="button wallet-download-button macos-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fa-apple wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Mac OSX Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/verge-android.apk" class="button wallet-download-button android-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fa-android wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Android Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/arch_2.1.0.tar" class="button wallet-download-button arch-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fl-archlinux wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge ArchLinux Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/centos7_2.1.0.tar" class="button wallet-download-button centos-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fl-centos wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge CentOS Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/debian8_v2.1.0.tar" class="button wallet-download-button debian-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fl-debian wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Debian Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/VERGE/releases/download/2.1/fedora23_2.1.0.tar" class="button wallet-download-button fedora-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fl-fedora wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Fedora Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="http://verge-wallet.xyz" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                View
-              </div>
-              <i class="fa fa-chrome wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Web Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/raspi/" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fl-raspberry-pi wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Raspberry Pi Source Code</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="http://vcmlfg3fgsmy2teu.onion" target="_blank" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa wallet-download-button-icon" aria-hidden="true">
-                <svg width="22" height="22" fill="white" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-                 <g transform="translate(-58.12 -303.3)">
-                  <path d="m77.15 303.3c-1.608 1.868-0.09027 2.972-0.9891 4.84 1.514-2.129 5.034-2.862 7.328-3.643-3.051 2.72-5.457 6.326-8.489 9.009l-1.975-0.8374c-0.4647-4.514-1.736-4.705 4.125-9.369z" fill-rule="evenodd"/>
-                  <path d="m74.04 313.1 2.932 0.9454c-0.615 2.034 0.3559 2.791 0.9472 3.123 1.324 0.7332 2.602 1.49 3.619 2.412 1.916 1.75 3.004 4.21 3.004 6.812 0 2.578-1.183 5.061-3.169 6.717-1.868 1.561-4.446 2.223-6.953 2.223-1.561 0-2.956-0.0708-4.47-0.5677-3.453-1.159-6.031-4.115-6.244-7.663-0.1893-2.767 0.4257-4.872 2.578-7.072 1.111-1.159 2.563-2.749 4.1-3.813 0.757-0.5204 1.119-1.191-0.4183-3.958l1.28-1.076 2.795 1.918-2.352-0.3007c0.1656 0.2366 1.189 0.7706 1.284 1.078 0.2128 0.8751-0.1911 1.771-0.3804 2.149-0.9696 1.75-1.86 2.275-3.066 3.268-2.129 1.75-4.27 2.836-4.01 7.637 0.1183 2.365 1.433 5.295 4.2 6.643 1.561 0.757 2.859 1.189 4.68 1.284 1.632 0.071 4.754-0.8988 6.457-2.318 1.821-1.514 2.838-3.808 2.838-6.149 0-2.365-0.9461-4.612-2.72-6.197-1.017-0.9223-2.696-2.034-3.737-2.625-1.041-0.5912-2.782-2.06-2.356-3.645z"/>
-                  <path d="m73.41 316.6c-0.186 1.088-0.4177 3.117-0.8909 3.917-0.3293 0.5488-0.4126 0.8101-0.7846 1.094-1.09 1.535-1.45 1.761-2.132 4.552-0.1447 0.5914-0.3832 1.516-0.2591 2.107 0.372 1.703 0.6612 2.874 1.316 4.103 0 0 0.1271 0.1217 0.1271 0.169 0.6821 0.9225 0.6264 1.05 2.665 2.246l-0.06204 0.3313c-1.55-0.4729-2.604-0.9591-3.41-2.024 0-0.0236-0.1513-0.1558-0.1513-0.1558-0.868-1.135-1.753-2.788-2.021-4.546-0.1447-0.7097-0.0769-1.341 0.08833-2.075 0.7026-2.885 1.415-4.093 2.744-5.543 0.3514-0.2601 0.6704-0.6741 1.001-1.092 0.4859-0.6764 1.462-2.841 1.814-4.189z"/>
-                  <path d="m74.09 318.6c0.0237 1.04 0.0078 3.036 0.3389 3.796 0.0945 0.2599 0.3274 1.414 0.9422 2.794 0.4258 0.96 0.5418 1.933 0.6128 2.193 0.2838 1.14-0.4002 3.086-0.8734 4.906-0.2364 0.98-0.6051 1.773-1.371 2.412l0.2796 0.3593c0.5204-0.02 1.954-1.096 2.403-2.416 0.757-2.24 1.328-3.317 0.9729-5.797-0.0473-0.2402-0.2094-1.134-0.6588-2.014-0.6622-1.34-1.474-2.614-1.592-2.874-0.213-0.4198-1.007-2.119-1.054-3.359z"/>
-                  <path d="m74.88 313.9 0.9727 0.4962c-0.09145 0.6403 0.04572 2.059 0.686 2.424 2.836 1.761 5.512 3.683 6.565 5.604 3.751 6.771-2.63 13.04-8.143 12.44 2.996-2.219 4.428-6.583 3.307-11.55-0.4574-1.944-1.729-3.893-2.987-5.883-0.545-0.9768-0.3547-2.188-0.4006-3.538z" fill-rule="evenodd"/>
-                  <rect x="73.07" y="312.8" width="1" height="22" />
-                 </g>
-                </svg>
-              </i>
-              <div class="wallet-download-button-description-text">Verge TOR Web Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="http://vhne4ia27avp7gtyltlj3fumq6ps343vap3gy3zqs7gj4yp2mbdq.b32.i2p/" target="_blank" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa wallet-download-button-icon" aria-hidden="true">
-              i2P
-              </i>
-              <div class="wallet-download-button-description-text">Verge i2P Web Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/electrum-xvg" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fa-linux wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Linux Electrum Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/electrum-xvg/releases/download/2.2.0.1/electrum-xvg.zip" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fa-windows wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Windows Electrum Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/electrum-xvg-tor" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa wallet-download-button-icon" aria-hidden="true">
-                <svg width="22" height="22" fill="white" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-                 <g transform="translate(-58.12 -303.3)">
-                  <path d="m77.15 303.3c-1.608 1.868-0.09027 2.972-0.9891 4.84 1.514-2.129 5.034-2.862 7.328-3.643-3.051 2.72-5.457 6.326-8.489 9.009l-1.975-0.8374c-0.4647-4.514-1.736-4.705 4.125-9.369z" fill-rule="evenodd"/>
-                  <path d="m74.04 313.1 2.932 0.9454c-0.615 2.034 0.3559 2.791 0.9472 3.123 1.324 0.7332 2.602 1.49 3.619 2.412 1.916 1.75 3.004 4.21 3.004 6.812 0 2.578-1.183 5.061-3.169 6.717-1.868 1.561-4.446 2.223-6.953 2.223-1.561 0-2.956-0.0708-4.47-0.5677-3.453-1.159-6.031-4.115-6.244-7.663-0.1893-2.767 0.4257-4.872 2.578-7.072 1.111-1.159 2.563-2.749 4.1-3.813 0.757-0.5204 1.119-1.191-0.4183-3.958l1.28-1.076 2.795 1.918-2.352-0.3007c0.1656 0.2366 1.189 0.7706 1.284 1.078 0.2128 0.8751-0.1911 1.771-0.3804 2.149-0.9696 1.75-1.86 2.275-3.066 3.268-2.129 1.75-4.27 2.836-4.01 7.637 0.1183 2.365 1.433 5.295 4.2 6.643 1.561 0.757 2.859 1.189 4.68 1.284 1.632 0.071 4.754-0.8988 6.457-2.318 1.821-1.514 2.838-3.808 2.838-6.149 0-2.365-0.9461-4.612-2.72-6.197-1.017-0.9223-2.696-2.034-3.737-2.625-1.041-0.5912-2.782-2.06-2.356-3.645z"/>
-                  <path d="m73.41 316.6c-0.186 1.088-0.4177 3.117-0.8909 3.917-0.3293 0.5488-0.4126 0.8101-0.7846 1.094-1.09 1.535-1.45 1.761-2.132 4.552-0.1447 0.5914-0.3832 1.516-0.2591 2.107 0.372 1.703 0.6612 2.874 1.316 4.103 0 0 0.1271 0.1217 0.1271 0.169 0.6821 0.9225 0.6264 1.05 2.665 2.246l-0.06204 0.3313c-1.55-0.4729-2.604-0.9591-3.41-2.024 0-0.0236-0.1513-0.1558-0.1513-0.1558-0.868-1.135-1.753-2.788-2.021-4.546-0.1447-0.7097-0.0769-1.341 0.08833-2.075 0.7026-2.885 1.415-4.093 2.744-5.543 0.3514-0.2601 0.6704-0.6741 1.001-1.092 0.4859-0.6764 1.462-2.841 1.814-4.189z"/>
-                  <path d="m74.09 318.6c0.0237 1.04 0.0078 3.036 0.3389 3.796 0.0945 0.2599 0.3274 1.414 0.9422 2.794 0.4258 0.96 0.5418 1.933 0.6128 2.193 0.2838 1.14-0.4002 3.086-0.8734 4.906-0.2364 0.98-0.6051 1.773-1.371 2.412l0.2796 0.3593c0.5204-0.02 1.954-1.096 2.403-2.416 0.757-2.24 1.328-3.317 0.9729-5.797-0.0473-0.2402-0.2094-1.134-0.6588-2.014-0.6622-1.34-1.474-2.614-1.592-2.874-0.213-0.4198-1.007-2.119-1.054-3.359z"/>
-                  <path d="m74.88 313.9 0.9727 0.4962c-0.09145 0.6403 0.04572 2.059 0.686 2.424 2.836 1.761 5.512 3.683 6.565 5.604 3.751 6.771-2.63 13.04-8.143 12.44 2.996-2.219 4.428-6.583 3.307-11.55-0.4574-1.944-1.729-3.893-2.987-5.883-0.545-0.9768-0.3547-2.188-0.4006-3.538z" fill-rule="evenodd"/>
-                  <rect x="73.07" y="312.8" width="1" height="22"/>
-                 </g>
-                </svg>
-              </i>
-              <div class="wallet-download-button-description-text">Verge TOR Linux Electrum Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/electrum-xvg-tor/releases/download/2.2.0.1/electrum-xvg-tor-win64.zip" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa wallet-download-button-icon" aria-hidden="true">
-                <svg width="22" height="22" fill="white" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-                 <g transform="translate(-58.12 -303.3)">
-                  <path d="m77.15 303.3c-1.608 1.868-0.09027 2.972-0.9891 4.84 1.514-2.129 5.034-2.862 7.328-3.643-3.051 2.72-5.457 6.326-8.489 9.009l-1.975-0.8374c-0.4647-4.514-1.736-4.705 4.125-9.369z" fill-rule="evenodd"/>
-                  <path d="m74.04 313.1 2.932 0.9454c-0.615 2.034 0.3559 2.791 0.9472 3.123 1.324 0.7332 2.602 1.49 3.619 2.412 1.916 1.75 3.004 4.21 3.004 6.812 0 2.578-1.183 5.061-3.169 6.717-1.868 1.561-4.446 2.223-6.953 2.223-1.561 0-2.956-0.0708-4.47-0.5677-3.453-1.159-6.031-4.115-6.244-7.663-0.1893-2.767 0.4257-4.872 2.578-7.072 1.111-1.159 2.563-2.749 4.1-3.813 0.757-0.5204 1.119-1.191-0.4183-3.958l1.28-1.076 2.795 1.918-2.352-0.3007c0.1656 0.2366 1.189 0.7706 1.284 1.078 0.2128 0.8751-0.1911 1.771-0.3804 2.149-0.9696 1.75-1.86 2.275-3.066 3.268-2.129 1.75-4.27 2.836-4.01 7.637 0.1183 2.365 1.433 5.295 4.2 6.643 1.561 0.757 2.859 1.189 4.68 1.284 1.632 0.071 4.754-0.8988 6.457-2.318 1.821-1.514 2.838-3.808 2.838-6.149 0-2.365-0.9461-4.612-2.72-6.197-1.017-0.9223-2.696-2.034-3.737-2.625-1.041-0.5912-2.782-2.06-2.356-3.645z"/>
-                  <path d="m73.41 316.6c-0.186 1.088-0.4177 3.117-0.8909 3.917-0.3293 0.5488-0.4126 0.8101-0.7846 1.094-1.09 1.535-1.45 1.761-2.132 4.552-0.1447 0.5914-0.3832 1.516-0.2591 2.107 0.372 1.703 0.6612 2.874 1.316 4.103 0 0 0.1271 0.1217 0.1271 0.169 0.6821 0.9225 0.6264 1.05 2.665 2.246l-0.06204 0.3313c-1.55-0.4729-2.604-0.9591-3.41-2.024 0-0.0236-0.1513-0.1558-0.1513-0.1558-0.868-1.135-1.753-2.788-2.021-4.546-0.1447-0.7097-0.0769-1.341 0.08833-2.075 0.7026-2.885 1.415-4.093 2.744-5.543 0.3514-0.2601 0.6704-0.6741 1.001-1.092 0.4859-0.6764 1.462-2.841 1.814-4.189z"/>
-                  <path d="m74.09 318.6c0.0237 1.04 0.0078 3.036 0.3389 3.796 0.0945 0.2599 0.3274 1.414 0.9422 2.794 0.4258 0.96 0.5418 1.933 0.6128 2.193 0.2838 1.14-0.4002 3.086-0.8734 4.906-0.2364 0.98-0.6051 1.773-1.371 2.412l0.2796 0.3593c0.5204-0.02 1.954-1.096 2.403-2.416 0.757-2.24 1.328-3.317 0.9729-5.797-0.0473-0.2402-0.2094-1.134-0.6588-2.014-0.6622-1.34-1.474-2.614-1.592-2.874-0.213-0.4198-1.007-2.119-1.054-3.359z"/>
-                  <path d="m74.88 313.9 0.9727 0.4962c-0.09145 0.6403 0.04572 2.059 0.686 2.424 2.836 1.761 5.512 3.683 6.565 5.604 3.751 6.771-2.63 13.04-8.143 12.44 2.996-2.219 4.428-6.583 3.307-11.55-0.4574-1.944-1.729-3.893-2.987-5.883-0.545-0.9768-0.3547-2.188-0.4006-3.538z" fill-rule="evenodd"/>
-                  <rect x="73.07" y="312.8" width="1" height="22"/>
-                 </g>
-                </svg>
-              </i>
-              <div class="wallet-download-button-description-text">Verge TOR Windows Electrum Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="http://vergecurrency.com/paper-wallet/index.html" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fa-newspaper-o wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Paper Wallet</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://github.com/vergecurrency/Docker-Verge-Daemon/" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fl-docker wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Verge Daemon Docker Image</div>
-            </a>
-          </li>
-          <li class="col-xs-12 col-sm-6 col-md-4">
-            <a href="https://play.google.com/store/apps/details?id=com.coinomi.wallet" class="button wallet-download-button">
-              <div class="wallet-download-button-download-text">
-                Download
-              </div>
-              <i class="fa fa-android wallet-download-button-icon" aria-hidden="true"></i>
-              <div class="wallet-download-button-description-text">Coinomi Multi Currency Android Wallet</div>
-            </a>
-          </li>
-        </ul>
     </div>
   </div>
 </section>


### PR DESCRIPTION
@vergecurrency @CryptoRekt @hellokarma

This PR does the following:

- Updates the Verge wallet section by adding **Desktop**, **Mobile**, and **Other** tabs

![wallet-tabs](https://user-images.githubusercontent.com/595663/27318004-d31866d6-553e-11e7-82ff-bbf1c3841d43.gif)


_Desktop_
![screen shot 2017-06-19 at 10 30 02 pm](https://user-images.githubusercontent.com/595663/27318047-02afd488-553f-11e7-8220-34f16adf4746.png)

_Mobile Web_
![screen shot 2017-06-19 at 10 30 37 pm](https://user-images.githubusercontent.com/595663/27318049-0796713c-553f-11e7-90ad-370d39d40911.png)
