### PR TITLE
Update the Roadmap to a Light Theme

### DIFF
--- a/_includes/home/roadmap.html
+++ b/_includes/home/roadmap.html
@@ -8,7 +8,7 @@
             <div class="cd-timeline-img completed cd-picture">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.blackpaper.header | default: defaultLangPath.roadmap.blackpaper.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.blackpaper.date | default: defaultLangPath.roadmap.blackpaper.date}}</span>
             </div>
@@ -17,7 +17,7 @@
             <div class="cd-timeline-img completed cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.electrum_i2P_server_client.header | default: defaultLangPath.roadmap.electrum_i2P_server_client.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.electrum_i2P_server_client.date | default: defaultLangPath.roadmap.electrum_i2P_server_client.date}}</span>
             </div>
@@ -26,7 +26,7 @@
             <div class="cd-timeline-img completed cd-picture">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.electrum_tor_server_client.header | default: defaultLangPath.roadmap.electrum_tor_server_client.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.electrum_tor_server_client.date | default: defaultLangPath.roadmap.electrum_tor_server_client.date}}</span>
             </div>
@@ -35,7 +35,7 @@
             <div class="cd-timeline-img completed cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.electrum_binaries.header | default: defaultLangPath.roadmap.electrum_binaries.header}}</h2>
                 <p>
                   {{langPath.roadmap.electrum_binaries.paragraph | default: defaultLangPath.roadmap.electrum_binaries.paragraph}}
@@ -47,7 +47,7 @@
             <div class="cd-timeline-img completed cd-picture">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.marketing_campaign.header | default: defaultLangPath.roadmap.marketing_campaign.header}}</h2>
               <p>
                 {{langPath.roadmap.marketing_campaign.paragraph | default: defaultLangPath.roadmap.marketing_campaign.paragraph}}
@@ -59,7 +59,7 @@
             <div class="cd-timeline-img completed cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.redesign_website.header | default: defaultLangPath.roadmap.redesign_website.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.redesign_website.date | default: defaultLangPath.roadmap.redesign_website.date}}</span>
             </div>
@@ -68,7 +68,7 @@
             <div class="cd-timeline-img completed cd-picture">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.radio.header | default: defaultLangPath.roadmap.radio.header}}</h2>
               <p>
                 {{langPath.roadmap.radio.paragraph | default: defaultLangPath.roadmap.radio.paragraph}}
@@ -80,7 +80,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.tor_android_wallet.header | default: defaultLangPath.roadmap.tor_android_wallet.header}}</h2>
               <p>
                 {{langPath.roadmap.tor_android_wallet.paragraph | default: defaultLangPath.roadmap.tor_android_wallet.paragraph}}
@@ -92,7 +92,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.i2P_android_wallet.header | default: defaultLangPath.roadmap.i2P_tor_android_wallet.header}}</h2>
               <p>
                 {{langPath.roadmap.i2P_android_wallet.paragraph | default: defaultLangPath.roadmap.i2P_android_wallet.paragraph}}
@@ -104,7 +104,7 @@
             <div class="cd-timeline-img cd-picture">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.core_wallet_release.header | default: defaultLangPath.roadmap.core_wallet_release.header}}</h2>
               <p>
                 {{langPath.roadmap.core_wallet_release.paragraph | default: defaultLangPath.roadmap.core_wallet_release.paragraph}}
@@ -116,7 +116,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.rsk_smart_contracts.header | default: defaultLangPath.roadmap.rsk_smart_contracts.header}}</h2>
               <p>
                 {{langPath.roadmap.rsk_smart_contracts.paragraph | default: defaultLangPath.roadmap.rsk_smart_contracts.paragraph}}
@@ -128,7 +128,7 @@
             <div class="cd-timeline-img cd-picture">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.wallet_ui.header | default: defaultLangPath.roadmap.wallet_ui.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.wallet_ui.date | default: defaultLangPath.roadmap.wallet_ui.date}}</span>
             </div>
@@ -137,7 +137,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.merchandise_store.header | default: defaultLangPath.roadmap.merchandise_store.header}}</h2>
               <p>
                 {{langPath.roadmap.merchandise_store.paragraph | default: defaultLangPath.roadmap.merchandise_store.paragraph}}
@@ -149,7 +149,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.transfer_discord_service.header | default: defaultLangPath.roadmap.transfer_discord_service.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.transfer_discord_service.date | default: defaultLangPath.roadmap.transfer_discord_service.date}}</span>
             </div>
@@ -158,7 +158,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.transfer_telegram_service.header | default: defaultLangPath.roadmap.transfer_telegram_service.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.transfer_telegram_service.date | default: defaultLangPath.roadmap.transfer_telegram_service.date}}</span>
             </div>
@@ -167,7 +167,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.official_mining_pool.header | default: defaultLangPath.roadmap.official_mining_pool.header}}</h2>
               <p>
                 {{langPath.roadmap.official_mining_pool.paragraph | default: defaultLangPath.roadmap.official_mining_pool.paragraph}}
@@ -179,7 +179,7 @@
             <div class="cd-timeline-img cd-movie">
               <i class="fa fa-check"></i>
             </div>
-            <div class="cd-timeline-content">
+            <div class="cd-timeline-content card">
               <h2>{{langPath.roadmap.upgrade_electrum_client.header | default: defaultLangPath.roadmap.upgrade_electrum_client.header}}</h2>
               <span class="cd-date">{{langPath.roadmap.upgrade_electrum_client.date | default: defaultLangPath.roadmap.upgrade_electrum_client.date}}</span>
             </div>

--- a/_sass/roadmap.scss
+++ b/_sass/roadmap.scss
@@ -86,16 +86,13 @@ Roadmap
   position: relative;
   margin-left: 60px;
   margin-right: 30px;
-  background: $bg-dark2;
   border-radius: 2px;
   padding: 1em;
 
   .timeline-content-info {
-    background: $bg-dark;
     padding: 5px 10px;
-    color: rgba(255,255,255,0.7);
+    color: $text-dark;
     font-size: 12px;
-    box-shadow:  inset 0 2px 0 rgba(0, 0, 0, 0.08);
     border-radius: 2px;
 
     i {
@@ -128,7 +125,7 @@ Roadmap
       border-radius: 2px;
       display: inline-block;
       padding: 2px 10px;
-      color: rgba(255,255,255,0.7);
+      color: $text-dark;
       margin: 3px 2px;
       text-align: center;
       flex-grow: 1;
@@ -143,13 +140,13 @@ Roadmap
 }
 
 .cd-timeline-content h2 {
-  color: rgba(255,255,255,.9);
+  color: $text-dark;
   margin-top:0;
   margin-bottom: 5px;
 }
 
 .cd-timeline-content p, .cd-timeline-content .cd-date {
-  color: rgba(255,255,255,.7);
+  color: $text-dark;
   font-size: 13px;
   font-size: 0.8125rem;
 }
@@ -170,8 +167,6 @@ Roadmap
   right: 100%;
   height: 0;
   width: 0;
-  border: 10px solid transparent;
-  border-right: 10px solid $bg-dark2;
 }
 
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
@vergecurrency @CryptoRekt 

This PR does the following:

  - Updates the roadmap to a light theme to mesh better with the rest of the site

![screen shot 2017-07-15 at 7 51 59 pm](https://user-images.githubusercontent.com/595663/28244145-1a5f5fba-6997-11e7-8db1-31ff5c412a2e.png)
