### PR TITLE
Removed unused blog anchor+

### DIFF
--- a/_includes/shared/header.html
+++ b/_includes/shared/header.html
@@ -54,9 +54,6 @@
             <li>
               <a href="{{linkPath}}#social">{{langPath.nav.social.title | default: defaultLangPath.nav.social.title}}</a>
             </li>
-            <Li>
-              <a href="{{linkPath}}#blog">{{langPath.nav.blog.title | default: defaultLangPath.nav.blog.title}}</a>
-            </Li>
           </ul>
         </li>
         {% if include.hideLangDropdown == false %}


### PR DESCRIPTION
From the 'Community' entry of the menu which appears when scroll all the way up.

Before:
![screen shot 2017-11-09 at 12 59 10 am](https://user-images.githubusercontent.com/1277279/32596825-80ec454c-c4e9-11e7-925f-005352eb4ddf.png)
After:
![screen shot 2017-11-09 at 12 59 24 am](https://user-images.githubusercontent.com/1277279/32596826-81152200-c4e9-11e7-8c52-6b1177aa04a7.png)