### PR TITLE
Dutch translation improved and changed date on Road Map to correct ones

### DIFF
--- a/_data/langs/nl.yml
+++ b/_data/langs/nl.yml
@@ -120,22 +120,22 @@ roadmap:
   i2P_android_wallet:
     header: "I2P Android Portemonnees"
     paragraph: "Android Wallet voor anonieme transacties! (Bijna voltooid)"
-    date: "Juli 2017"
+    date: "Q4 2017"
   core_wallet_release:
     header: "Nieuwe Core Wallet Release"
     paragraph: "Toevoegen van nieuwe functies, waaronder muntregeling, RingCT, update van software bibliotheken (openssl, boost, etc)"
-    date: "Juli 2017"
+    date: "Q4 2017"
   rsk_smart_contracts:
     header: "RSK slimme contracten"
-    paragraph: "Ze zijn nu in testnet voor bitcoin. Datum komt nog."
-    date: "Juli 2017"
+    paragraph: "Verge is in het testnet voor bitcoin. Datum komt nog."
+    date: "Q4/Q1, 2017/2018"
   wallet_ui:
     header: "Wallet UI revisie"
     date: "Juli 2017"
   merchandise_store:
     header: "Merchandise Online Store"
     paragraph: "Verge producten zoals t-shirts kunnen binnekort worden gekocht met XVG of BTC."
-    date: "Juli 2017"
+    date: "Q4 2017"
 footer:
   social:
     header: "Community"


### PR DESCRIPTION
I updated the Dutch translation to the correct date. With the current translation it says that Core Wallet 3.0 will be out at July 2017. I corrected the Online Merchandising Store, i2P android wallet and RSK Smart Contracts according to the English translation