### PR TITLE
changed xvg donation link

### DIFF
--- a/_includes/home/donate.html
+++ b/_includes/home/donate.html
@@ -10,7 +10,7 @@
       <img class="donate-verge-logo" src="../../images/favicon/mstile-310x310.png" alt="Verge" title="Verge">
       <h3 class="donate-wallet-header">{{langPath.donate.wallets.verge.header | default: defaultLangPath.donate.wallets.verge.header}}</h3>
       <div>
-        <a href="https://prohashing.com/explorer/Verge/{{langPath.donate.wallets.verge.address | defaultLangPath.donate.wallets.verge.address}}" target="_blank">
+        <a href="https://verge-blockchain.info/address/{{langPath.donate.wallets.verge.address | defaultLangPath.donate.wallets.verge.address}}" target="_blank">
           {{langPath.donate.wallets.verge.address | default: defaultLangPath.donate.wallets.verge.address}}
         </a>
       </div>


### PR DESCRIPTION
since verge-blockchain.info is released we should use this explorer instead of prohashing, because it's focus is to xvg instead of every crypto currency