### PR TITLE
chore: donation page grammar fix

### DIFF
--- a/_includes/donate.html
+++ b/_includes/donate.html
@@ -19,8 +19,8 @@
           <li><strong>Partnerships with large scale companies</strong></li>
           <li><strong>Real world adoption</strong></li>
         </ul>
-        <p style="margin-top: 1.5em; margin-bottom: 1.5em;">At Verge we are always striving to achieve new heights and deliver products or software implementations that are requested by the community. Listening to our community members and taking in feedback is not only one of the core founding principles of Verge but it is inherent in our open source nature. Verge is continuously looking to grow and improve to ensure you, the user of our product, are getting the best possible experience you can.</p>
-        <p style="margin-bottom: 1.5em;">As many of you are aware no one on the Verge staff are paid to do the work they do and generally any marketing efforts that come from our team are funded out of our own day job salaries. That is why we need your help. In order for us to be able to provide these services to you, our community, we need to raise a substantial amount of funding.</p>        
+        <p style="margin-top: 1.5em; margin-bottom: 1.5em;">At Verge we are always striving to achieve new heights and deliver products or software implementations that are requested by the community. Listening to our community members and taking in feedback is not only one of the core founding principles of Verge, but it is inherent in our open-source nature. Verge is continuously looking to grow and improve to ensure you, the user of our product, are getting the best possible experience you can.</p>
+        <p style="margin-bottom: 1.5em;">As many of you are aware, no one on the Verge staff is paid to do the work they do and generally any marketing efforts that come from our team are funded out of our own day job salaries. That is why we need your help. In order for us to be able to provide these services to you, our community, we need to raise a substantial amount of funding.</p>        
         <p style="margin-bottom: 1.5em;">Below you will find a donation address, anything you can contribute is greatly appreciated.</p>
       </div>
     </div>


### PR DESCRIPTION
Added commas for better flow. Added hyphen. Use "is" instead of "are" when the object of the sentence is not plural. If I may make a suggestion, the Verge team needs to pay closer attention to things like this. Especially on the official Twitter, which freqently has missing capital letters, lack of punctuation, typos, etc.